### PR TITLE
⚠️ [WIP] Deprecating and replacing securityGroups field from OpenStackMachineTemplate ports level

### DIFF
--- a/api/v1alpha4/conversion.go
+++ b/api/v1alpha4/conversion.go
@@ -198,6 +198,15 @@ func Convert_v1alpha4_PortOpts_To_v1alpha5_PortOpts(in *PortOpts, out *infrav1.P
 	if in.NetworkID != "" {
 		out.Network = &infrav1.NetworkFilter{ID: in.NetworkID}
 	}
+	var v1alpha5securityGroups []infrav1.SecurityGroupParam
+	if in.SecurityGroups != nil {
+		for _, v1alpha4SecurityGroupUID := range *in.SecurityGroups {
+			if v1alpha4SecurityGroupUID != "" {
+				v1alpha5securityGroups = append(v1alpha5securityGroups, infrav1.SecurityGroupParam{UUID: v1alpha4SecurityGroupUID})
+			}
+		}
+		out.SecurityGroups = &v1alpha5securityGroups
+	}
 	return nil
 }
 
@@ -208,6 +217,15 @@ func Convert_v1alpha5_PortOpts_To_v1alpha4_PortOpts(in *infrav1.PortOpts, out *P
 	}
 	if in.Network != nil {
 		out.NetworkID = in.Network.ID
+	}
+	var v1alpha4securityGroups []string
+	if in.SecurityGroups != nil {
+		for _, v1alpha5SecurityGroups := range *in.SecurityGroups {
+			if v1alpha5SecurityGroups.UUID != "" {
+				v1alpha4securityGroups = append(v1alpha4securityGroups, v1alpha5SecurityGroups.UUID)
+			}
+		}
+		out.SecurityGroups = &v1alpha4securityGroups
 	}
 	return nil
 }

--- a/api/v1alpha4/conversion_test.go
+++ b/api/v1alpha4/conversion_test.go
@@ -264,7 +264,6 @@ func TestFuzzyConversion(t *testing.T) {
 						v1alpha5PortOpts.Network = nil
 					}
 				}
-				v1alpha5PortOpts.SecurityGroupFilters = nil
 			},
 			func(v1alpha5FixedIP *infrav1.FixedIP, c fuzz.Continue) {
 				c.FuzzNoCustom(v1alpha5FixedIP)

--- a/api/v1alpha4/zz_generated.conversion.go
+++ b/api/v1alpha4/zz_generated.conversion.go
@@ -1443,7 +1443,7 @@ func autoConvert_v1alpha4_PortOpts_To_v1alpha5_PortOpts(in *PortOpts, out *v1alp
 	}
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
+	// WARNING: in.SecurityGroups requires manual conversion: inconvertible types (*[]string vs []sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha5.SecurityGroupParam)
 	out.AllowedAddressPairs = *(*[]v1alpha5.AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
 	out.HostID = in.HostID
@@ -1473,8 +1473,7 @@ func autoConvert_v1alpha5_PortOpts_To_v1alpha4_PortOpts(in *v1alpha5.PortOpts, o
 	}
 	out.TenantID = in.TenantID
 	out.ProjectID = in.ProjectID
-	out.SecurityGroups = (*[]string)(unsafe.Pointer(in.SecurityGroups))
-	// WARNING: in.SecurityGroupFilters requires manual conversion: does not exist in peer-type
+	// WARNING: in.SecurityGroups requires manual conversion: inconvertible types ([]sigs.k8s.io/cluster-api-provider-openstack/api/v1alpha5.SecurityGroupParam vs *[]string)
 	out.AllowedAddressPairs = *(*[]AddressPair)(unsafe.Pointer(&in.AllowedAddressPairs))
 	out.Trunk = (*bool)(unsafe.Pointer(in.Trunk))
 	out.HostID = in.HostID

--- a/api/v1alpha5/types.go
+++ b/api/v1alpha5/types.go
@@ -117,11 +117,9 @@ type PortOpts struct {
 	FixedIPs  []FixedIP `json:"fixedIPs,omitempty"`
 	TenantID  string    `json:"tenantId,omitempty"`
 	ProjectID string    `json:"projectId,omitempty"`
-	// The uuids of the security groups to assign to the instance
-	SecurityGroups *[]string `json:"securityGroups,omitempty"`
-	// The names, uuids, filters or any combination these of the security groups to assign to the instance
-	SecurityGroupFilters []SecurityGroupParam `json:"securityGroupFilters,omitempty"`
-	AllowedAddressPairs  []AddressPair        `json:"allowedAddressPairs,omitempty"`
+	// The names of the security groups to assign to the port
+	SecurityGroups      *[]SecurityGroupParam `json:"securityGroups,omitempty"`
+	AllowedAddressPairs []AddressPair         `json:"allowedAddressPairs,omitempty"`
 	// Enables and disables trunk at port level. If not provided, openStackMachine.Spec.Trunk is inherited.
 	Trunk *bool `json:"trunk,omitempty"`
 

--- a/api/v1alpha5/zz_generated.deepcopy.go
+++ b/api/v1alpha5/zz_generated.deepcopy.go
@@ -815,17 +815,12 @@ func (in *PortOpts) DeepCopyInto(out *PortOpts) {
 	}
 	if in.SecurityGroups != nil {
 		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = new([]string)
+		*out = new([]SecurityGroupParam)
 		if **in != nil {
 			in, out := *in, *out
-			*out = make([]string, len(*in))
+			*out = make([]SecurityGroupParam, len(*in))
 			copy(*out, *in)
 		}
-	}
-	if in.SecurityGroupFilters != nil {
-		in, out := &in.SecurityGroupFilters, &out.SecurityGroupFilters
-		*out = make([]SecurityGroupParam, len(*in))
-		copy(*out, *in)
 	}
 	if in.AllowedAddressPairs != nil {
 		in, out := &in.AllowedAddressPairs, &out.AllowedAddressPairs

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclusters.yaml
@@ -2779,9 +2779,9 @@ spec:
                               type: object
                             projectId:
                               type: string
-                            securityGroupFilters:
-                              description: The names, uuids, filters or any combination
-                                these of the security groups to assign to the instance
+                            securityGroups:
+                              description: The names of the security groups to assign
+                                to the port
                               items:
                                 properties:
                                   filter:
@@ -2822,12 +2822,6 @@ spec:
                                     description: Security Group UID
                                     type: string
                                 type: object
-                              type: array
-                            securityGroups:
-                              description: The uuids of the security groups to assign
-                                to the instance
-                              items:
-                                type: string
                               type: array
                             tags:
                               description: Tags applied to the port (and corresponding
@@ -3298,9 +3292,9 @@ spec:
                               type: object
                             projectId:
                               type: string
-                            securityGroupFilters:
-                              description: The names, uuids, filters or any combination
-                                these of the security groups to assign to the instance
+                            securityGroups:
+                              description: The names of the security groups to assign
+                                to the port
                               items:
                                 properties:
                                   filter:
@@ -3341,12 +3335,6 @@ spec:
                                     description: Security Group UID
                                     type: string
                                 type: object
-                              type: array
-                            securityGroups:
-                              description: The uuids of the security groups to assign
-                                to the instance
-                              items:
-                                type: string
                               type: array
                             tags:
                               description: Tags applied to the port (and corresponding
@@ -3678,9 +3666,9 @@ spec:
                         type: object
                       projectId:
                         type: string
-                      securityGroupFilters:
-                        description: The names, uuids, filters or any combination
-                          these of the security groups to assign to the instance
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the port
                         items:
                           properties:
                             filter:
@@ -3721,12 +3709,6 @@ spec:
                               description: Security Group UID
                               type: string
                           type: object
-                        type: array
-                      securityGroups:
-                        description: The uuids of the security groups to assign to
-                          the instance
-                        items:
-                          type: string
                         type: array
                       tags:
                         description: Tags applied to the port (and corresponding trunk,
@@ -3972,9 +3954,9 @@ spec:
                         type: object
                       projectId:
                         type: string
-                      securityGroupFilters:
-                        description: The names, uuids, filters or any combination
-                          these of the security groups to assign to the instance
+                      securityGroups:
+                        description: The names of the security groups to assign to
+                          the port
                         items:
                           properties:
                             filter:
@@ -4015,12 +3997,6 @@ spec:
                               description: Security Group UID
                               type: string
                           type: object
-                        type: array
-                      securityGroups:
-                        description: The uuids of the security groups to assign to
-                          the instance
-                        items:
-                          type: string
                         type: array
                       tags:
                         description: Tags applied to the port (and corresponding trunk,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackclustertemplates.yaml
@@ -1049,10 +1049,9 @@ spec:
                                       type: object
                                     projectId:
                                       type: string
-                                    securityGroupFilters:
-                                      description: The names, uuids, filters or any
-                                        combination these of the security groups to
-                                        assign to the instance
+                                    securityGroups:
+                                      description: The names of the security groups
+                                        to assign to the port
                                       items:
                                         properties:
                                           filter:
@@ -1093,12 +1092,6 @@ spec:
                                             description: Security Group UID
                                             type: string
                                         type: object
-                                      type: array
-                                    securityGroups:
-                                      description: The uuids of the security groups
-                                        to assign to the instance
-                                      items:
-                                        type: string
                                       type: array
                                     tags:
                                       description: Tags applied to the port (and corresponding

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachines.yaml
@@ -1044,9 +1044,9 @@ spec:
                       type: object
                     projectId:
                       type: string
-                    securityGroupFilters:
-                      description: The names, uuids, filters or any combination these
-                        of the security groups to assign to the instance
+                    securityGroups:
+                      description: The names of the security groups to assign to the
+                        port
                       items:
                         properties:
                           filter:
@@ -1087,12 +1087,6 @@ spec:
                             description: Security Group UID
                             type: string
                         type: object
-                      type: array
-                    securityGroups:
-                      description: The uuids of the security groups to assign to the
-                        instance
-                      items:
-                        type: string
                       type: array
                     tags:
                       description: Tags applied to the port (and corresponding trunk,

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_openstackmachinetemplates.yaml
@@ -951,9 +951,9 @@ spec:
                               type: object
                             projectId:
                               type: string
-                            securityGroupFilters:
-                              description: The names, uuids, filters or any combination
-                                these of the security groups to assign to the instance
+                            securityGroups:
+                              description: The names of the security groups to assign
+                                to the port
                               items:
                                 properties:
                                   filter:
@@ -994,12 +994,6 @@ spec:
                                     description: Security Group UID
                                     type: string
                                 type: object
-                              type: array
-                            securityGroups:
-                              description: The uuids of the security groups to assign
-                                to the instance
-                              items:
-                                type: string
                               type: array
                             tags:
                               description: Tags applied to the port (and corresponding

--- a/pkg/cloud/services/networking/port.go
+++ b/pkg/cloud/services/networking/port.go
@@ -89,9 +89,15 @@ func (s *Service) GetOrCreatePort(eventObject runtime.Object, clusterName string
 				MACAddress: ap.MACAddress,
 			})
 		}
-		securityGroups, err = s.CollectPortSecurityGroups(eventObject, portOpts.SecurityGroups, portOpts.SecurityGroupFilters)
-		if err != nil {
-			return nil, err
+		portSecurityGroups := portOpts.SecurityGroups
+		if portSecurityGroups != nil {
+			portSecurityGroups, err := s.GetSecurityGroups(*portSecurityGroups)
+			if err != nil {
+				return nil, fmt.Errorf("error getting security groups: %v", err)
+			}
+			if len(portSecurityGroups) > 0 {
+				securityGroups = &portSecurityGroups
+			}
 		}
 		// inherit port security groups from the instance if not explicitly specified
 		if securityGroups == nil || len(*securityGroups) == 0 {
@@ -257,42 +263,4 @@ func (s *Service) GarbageCollectErrorInstancesPort(eventObject runtime.Object, i
 	}
 
 	return nil
-}
-
-// CollectPortSecurityGroups collects distinct securityGroups from port.SecurityGroups and port.SecurityGroupFilter fields.
-func (s *Service) CollectPortSecurityGroups(eventObject runtime.Object, portSecurityGroups *[]string, portSecurityGroupFilters []infrav1.SecurityGroupParam) (*[]string, error) {
-	var allSecurityGroupIDs []string
-	// security groups provided with the portSecurityGroupFilters fields
-	securityGroupFiltersByID, err := s.GetSecurityGroups(portSecurityGroupFilters)
-	if err != nil {
-		return portSecurityGroups, fmt.Errorf("error getting security groups: %v", err)
-	}
-	allSecurityGroupIDs = append(allSecurityGroupIDs, securityGroupFiltersByID...)
-	securityGroupCount := 0
-	// security groups provided with the portSecurityGroups fields
-	if portSecurityGroups != nil {
-		allSecurityGroupIDs = append(allSecurityGroupIDs, *portSecurityGroups...)
-	}
-	// generate unique values
-	uids := make(map[string]int)
-	for _, sg := range allSecurityGroupIDs {
-		if sg == "" {
-			continue
-		}
-		// count distinct values
-		_, ok := uids[sg]
-		if !ok {
-			securityGroupCount++
-		}
-		uids[sg] = 1
-	}
-	distinctSecurityGroupIDs := make([]string, 0, securityGroupCount)
-	// collect distict values
-	for key := range uids {
-		if key == "" {
-			continue
-		}
-		distinctSecurityGroupIDs = append(distinctSecurityGroupIDs, key)
-	}
-	return &distinctSecurityGroupIDs, nil
 }

--- a/pkg/cloud/services/networking/port_test.go
+++ b/pkg/cloud/services/networking/port_test.go
@@ -49,8 +49,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 
 	// Other arbitrary variables passed in to the tests
 	instanceSecurityGroups := []string{"instance-secgroup"}
-	portSecurityGroups := []string{"port-secgroup"}
-
+	portSecurityGroups := []infrav1.SecurityGroupParam{{Name: "port-secgroup"}}
 	pointerToTrue := pointerTo(true)
 	pointerToFalse := pointerTo(false)
 
@@ -199,7 +198,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 					},
 					TenantID:       tenantID,
 					ProjectID:      projectID,
-					SecurityGroups: &portSecurityGroups,
+					SecurityGroups: &instanceSecurityGroups,
 					AllowedAddressPairs: []ports.AddressPair{{
 						IPAddress:  "10.10.10.10",
 						MACAddress: "f1:f1:f1:f1:f1:f1",
@@ -313,7 +312,7 @@ func Test_GetOrCreatePort(t *testing.T) {
 						CreateOptsBuilder: ports.CreateOpts{
 							Name:                "foo-port-1",
 							Description:         "Created by cluster-api-provider-openstack cluster test-cluster",
-							SecurityGroups:      &portSecurityGroups,
+							SecurityGroups:      &instanceSecurityGroups,
 							NetworkID:           netID,
 							AllowedAddressPairs: []ports.AddressPair{},
 						},

--- a/pkg/cloud/services/networking/securitygroups.go
+++ b/pkg/cloud/services/networking/securitygroups.go
@@ -393,6 +393,9 @@ func (s *Service) generateDesiredSecGroups(openStackCluster *infrav1.OpenStackCl
 func (s *Service) GetSecurityGroups(securityGroupParams []infrav1.SecurityGroupParam) ([]string, error) {
 	var sgIDs []string
 	for _, sg := range securityGroupParams {
+		if sg.UUID == "" {
+			continue
+		}
 		// Don't validate an explicit UUID if we were given one
 		if sg.UUID != "" {
 			if isDuplicate(sgIDs, sg.UUID) {


### PR DESCRIPTION
Deprecating and replacing `securityGroups` of `[]string `format field from OpenStackMachineTemplate ports and replace is by `[]SecurityGroupParam` format.


fixes: #1251